### PR TITLE
Refactor the `guard` and `negate` combinators

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -75,8 +75,6 @@
  *
  * -   `left` constructs a left-sided `Either`.
  * -   `right` constructs a right-sided `Either`.
- * -   `guard` constructs an `Either` from applying a predicate function to a
- *     value.
  * -   `fromValidation` constructs an `Either` from a `Validation`.
  *
  * ## Querying and narrowing the variant
@@ -422,21 +420,6 @@ export namespace Either {
      */
     export function right<B, A = never>(x: B): Either<A, B> {
         return new Right(x);
-    }
-
-    /**
-     * Apply a predicate function to a value. If the predicate returns `true`,
-     * return the value in `Right`; otherwise, return the value in `Left`.
-     */
-    export function guard<A, A1 extends A>(
-        x: A,
-        f: (x: A) => x is A1,
-    ): Either<Exclude<A, A1>, A1>;
-
-    export function guard<A>(x: A, f: (x: A) => boolean): Either<A, A>;
-
-    export function guard<A>(x: A, f: (x: A) => boolean): Either<A, A> {
-        return f(x) ? right(x) : left(x);
     }
 
     /**

--- a/src/fn.ts
+++ b/src/fn.ts
@@ -40,17 +40,18 @@ export function constant<A>(x: A): (...args: any[]) => A {
 }
 
 /**
- * Reverse a refinement function or a predicate function.
+ * Adapt a predicate of any arity into an identical predicate that negates its
+ * result.
  */
-export function negate<A, A1 extends A>(
+export function negatePred<A, A1 extends A>(
     f: (x: A) => x is A1,
 ): (x: A) => x is Exclude<A, A1>;
 
-export function negate<T extends unknown[]>(
+export function negatePred<T extends unknown[]>(
     f: (...args: T) => boolean,
 ): (...args: T) => boolean;
 
-export function negate<T extends unknown[]>(
+export function negatePred<T extends unknown[]>(
     f: (...args: T) => boolean,
 ): (...args: T) => boolean {
     return (...args) => !f(...args);

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -64,16 +64,17 @@
  *
  * ## Constructing `Maybe`
  *
- * The `nothing` constant is the singleton instance of of the `Nothing` variant
- * of `Maybe`.
+ * The `nothing` constant is the singleton instance of the absent `Maybe`.
  *
  * These functions construct a `Maybe`:
  *
- * -   `just` constructs a `Just` variant.
+ * -   `just` constructs a present `Maybe`.
  * -   `fromMissing` constructs a `Maybe` from a value that is potentially
- *     `null` or `undefined`, and converts such values to `Nothing`.
- * -   `guard` constructs a `Maybe` from applying a predicate function to a
- *     value.
+ *     `null` or `undefined`.
+ *
+ * These functions adapt other functions to return a `Maybe`:
+ *
+ * -   `wrapPred` adapts a predicate.
  *
  * ## Querying and narrowing the variant
  *
@@ -434,18 +435,21 @@ export namespace Maybe {
     }
 
     /**
-     * Apply a predicate function to a value. If the predicate returns `true`,
-     * return the value in a `Just`; otherwise, return `Nothing`.
+     * Adapt a predicate into a function that returns a `Maybe`.
+     *
+     * @remarks
+     *
+     * If the predicate returns `true`, return the argument in a `Just`;
+     * otherwise, return `Nothing`.
      */
-    export function guard<A, A1 extends A>(
-        x: A,
+    export function wrapPred<A, A1 extends A>(
         f: (x: A) => x is A1,
-    ): Maybe<A1>;
+    ): (x: A) => Maybe<A1>;
 
-    export function guard<A>(x: A, f: (x: A) => boolean): Maybe<A>;
+    export function wrapPred<A>(f: (x: A) => boolean): (x: A) => Maybe<A>;
 
-    export function guard<A>(x: A, f: (x: A) => boolean): Maybe<A> {
-        return f(x) ? just(x) : nothing;
+    export function wrapPred<A>(f: (x: A) => boolean): (x: A) => Maybe<A> {
+        return (x) => (f(x) ? just(x) : nothing);
     }
 
     /**

--- a/test/either_test.ts
+++ b/test/either_test.ts
@@ -20,16 +20,6 @@ const _3 = 3 as const;
 const _4 = 4 as const;
 
 describe("Either", () => {
-    specify("Either.guard", () => {
-        const f = (x: 2 | 4): x is 2 => x === _2;
-
-        const t0 = Either.guard(_2 as 2 | 4, f);
-        assert.deepEqual(t0, Either.right(_2));
-
-        const t1 = Either.guard(_4 as 2 | 4, f);
-        assert.deepEqual(t1, Either.left(_4));
-    });
-
     specify("Either.fromValidation", () => {
         const t0 = Either.fromValidation(Validation.err<1, 2>(_1));
         assert.deepEqual(t0, Either.left(_1));

--- a/test/fn_test.ts
+++ b/test/fn_test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import * as fc from "fast-check";
-import { id, negate, wrapCtor } from "../src/fn.js";
+import { id, negatePred, wrapCtor } from "../src/fn.js";
 
 describe("Functions", () => {
     specify("id", () => {
@@ -12,11 +12,11 @@ describe("Functions", () => {
         );
     });
 
-    specify("negate", () => {
+    specify("negatePred", () => {
         function f(x: 1 | 2): x is 2 {
             return x === 2;
         }
-        const g = negate(f);
+        const g = negatePred(f);
 
         assert.strictEqual(f(1), false);
         assert.strictEqual(f(2), true);

--- a/test/maybe_test.ts
+++ b/test/maybe_test.ts
@@ -30,13 +30,13 @@ describe("Maybe", () => {
         assert.deepEqual(t2, Maybe.just(_1));
     });
 
-    specify("Maybe.guard", () => {
+    specify("Maybe.wrapPred", () => {
         const f = (x: 1 | 2): x is 1 => x === _1;
 
-        const t0 = Maybe.guard(_1 as 1 | 2, f);
+        const t0 = Maybe.wrapPred(f)(_1 as 1 | 2);
         assert.deepEqual(t0, Maybe.just(_1));
 
-        const t1 = Maybe.guard(_2 as 1 | 2, f);
+        const t1 = Maybe.wrapPred(f)(_2 as 1 | 2);
         assert.deepEqual(t1, Maybe.nothing);
     });
 


### PR DESCRIPTION
- Remove the `guard` combinator for `Either`
- Replace the `guard` combinator for `Maybe` with the `wrapPred` higher order function
- Rename the `negate` combinator to `negatePred`