### PR TITLE
Improve how and when type tests are ran

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,4 +67,4 @@ jobs:
       - uses: volta-cli/action@v4
       - run: npm ci
       - run: npm i -D typescript@${{ matrix.ts-version }}
-      - run: npm test
+      - run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"prettier:check": "prettier --check --ignore-path ./.gitignore .",
 		"prettier:write": "prettier --write --ignore-path ./.gitignore .",
 		"style": "npm run lint && npm run prettier:check",
-		"test": "npm run typecheck && vitest run --coverage",
+		"test": "vitest run --coverage",
 		"test:watch": "vitest",
 		"typecheck": "tsc --skipLibCheck --noEmit",
 		"docs": "typedoc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "ES2022",
-		"module": "ES2022",
-		"moduleResolution": "NodeNext",
+		"module": "Node16",
 		"declaration": true,
 		"declarationMap": true,
 		"sourceMap": true,


### PR DESCRIPTION
Do not test types by default as part of the `npm test` command. Prefer `npm typecheck` instead.

Also, check only types inside of the CI TypeScript test matrix.