### PR TITLE
Upgrade Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"devDependencies": {
 				"@typescript-eslint/eslint-plugin": "^5.55.0",
 				"@typescript-eslint/parser": "^5.55.0",
-				"@vitest/coverage-c8": "^0.29.3",
+				"@vitest/coverage-v8": "^0.34.1",
 				"eslint": "^8.36.0",
 				"eslint-config-prettier": "^8.8.0",
 				"eslint-plugin-import": "^2.27.5",
@@ -22,10 +22,23 @@
 				"ts-node": "^10.9.1",
 				"typedoc": "0.23.28",
 				"typescript": "~5.0",
-				"vitest": "^0.29.3"
+				"vitest": "^0.34.1"
 			},
 			"engines": {
 				"node": "16.* || >= 18.*"
+			}
+		},
+		"node_modules/@ampproject/remapping": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@bcoe/v8-coverage": {
@@ -47,9 +60,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.12.tgz",
-			"integrity": "sha512-E/sgkvwoIfj4aMAPL2e35VnUJspzVYl7+M1B2cqeubdBhADV4uPon0KCc8p2G+LqSJ6i8ocYPCqY3A4GGq0zkQ==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+			"integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
 			"cpu": [
 				"arm"
 			],
@@ -63,9 +76,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.12.tgz",
-			"integrity": "sha512-WQ9p5oiXXYJ33F2EkE3r0FRDFVpEdcDiwNX3u7Xaibxfx6vQE0Sb8ytrfQsA5WO6kDn6mDfKLh6KrPBjvkk7xA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+			"integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -79,9 +92,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.12.tgz",
-			"integrity": "sha512-m4OsaCr5gT+se25rFPHKQXARMyAehHTQAz4XX1Vk3d27VtqiX0ALMBPoXZsGaB6JYryCLfgGwUslMqTfqeLU0w==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+			"integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
 			"cpu": [
 				"x64"
 			],
@@ -95,9 +108,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.12.tgz",
-			"integrity": "sha512-O3GCZghRIx+RAN0NDPhyyhRgwa19MoKlzGonIb5hgTj78krqp9XZbYCvFr9N1eUxg0ZQEpiiZ4QvsOQwBpP+lg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+			"integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
 			"cpu": [
 				"arm64"
 			],
@@ -111,9 +124,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.12.tgz",
-			"integrity": "sha512-5D48jM3tW27h1qjaD9UNRuN+4v0zvksqZSPZqeSWggfMlsVdAhH3pwSfQIFJwcs9QJ9BRibPS4ViZgs3d2wsCA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+			"integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
 			"cpu": [
 				"x64"
 			],
@@ -127,9 +140,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.12.tgz",
-			"integrity": "sha512-OWvHzmLNTdF1erSvrfoEBGlN94IE6vCEaGEkEH29uo/VoONqPnoDFfShi41Ew+yKimx4vrmmAJEGNoyyP+OgOQ==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+			"integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
 			"cpu": [
 				"arm64"
 			],
@@ -143,9 +156,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.12.tgz",
-			"integrity": "sha512-A0Xg5CZv8MU9xh4a+7NUpi5VHBKh1RaGJKqjxe4KG87X+mTjDE6ZvlJqpWoeJxgfXHT7IMP9tDFu7IZ03OtJAw==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+			"integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
 			"cpu": [
 				"x64"
 			],
@@ -159,9 +172,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.12.tgz",
-			"integrity": "sha512-WsHyJ7b7vzHdJ1fv67Yf++2dz3D726oO3QCu8iNYik4fb5YuuReOI9OtA+n7Mk0xyQivNTPbl181s+5oZ38gyA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+			"integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
 			"cpu": [
 				"arm"
 			],
@@ -175,9 +188,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.12.tgz",
-			"integrity": "sha512-cK3AjkEc+8v8YG02hYLQIQlOznW+v9N+OI9BAFuyqkfQFR+DnDLhEM5N8QRxAUz99cJTo1rLNXqRrvY15gbQUg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+			"integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
 			"cpu": [
 				"arm64"
 			],
@@ -191,9 +204,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.12.tgz",
-			"integrity": "sha512-jdOBXJqcgHlah/nYHnj3Hrnl9l63RjtQ4vn9+bohjQPI2QafASB5MtHAoEv0JQHVb/xYQTFOeuHnNYE1zF7tYw==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+			"integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
 			"cpu": [
 				"ia32"
 			],
@@ -207,9 +220,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.12.tgz",
-			"integrity": "sha512-GTOEtj8h9qPKXCyiBBnHconSCV9LwFyx/gv3Phw0pa25qPYjVuuGZ4Dk14bGCfGX3qKF0+ceeQvwmtI+aYBbVA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+			"integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
 			"cpu": [
 				"loong64"
 			],
@@ -223,9 +236,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.12.tgz",
-			"integrity": "sha512-o8CIhfBwKcxmEENOH9RwmUejs5jFiNoDw7YgS0EJTF6kgPgcqLFjgoc5kDey5cMHRVCIWc6kK2ShUePOcc7RbA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+			"integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -239,9 +252,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.12.tgz",
-			"integrity": "sha512-biMLH6NR/GR4z+ap0oJYb877LdBpGac8KfZoEnDiBKd7MD/xt8eaw1SFfYRUeMVx519kVkAOL2GExdFmYnZx3A==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+			"integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -255,9 +268,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.12.tgz",
-			"integrity": "sha512-jkphYUiO38wZGeWlfIBMB72auOllNA2sLfiZPGDtOBb1ELN8lmqBrlMiucgL8awBw1zBXN69PmZM6g4yTX84TA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+			"integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
 			"cpu": [
 				"riscv64"
 			],
@@ -271,9 +284,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.12.tgz",
-			"integrity": "sha512-j3ucLdeY9HBcvODhCY4b+Ds3hWGO8t+SAidtmWu/ukfLLG/oYDMaA+dnugTVAg5fnUOGNbIYL9TOjhWgQB8W5g==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+			"integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -287,9 +300,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.12.tgz",
-			"integrity": "sha512-uo5JL3cgaEGotaqSaJdRfFNSCUJOIliKLnDGWaVCgIKkHxwhYMm95pfMbWZ9l7GeW9kDg0tSxcy9NYdEtjwwmA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+			"integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
 			"cpu": [
 				"x64"
 			],
@@ -303,9 +316,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.12.tgz",
-			"integrity": "sha512-DNdoRg8JX+gGsbqt2gPgkgb00mqOgOO27KnrWZtdABl6yWTST30aibGJ6geBq3WM2TIeW6COs5AScnC7GwtGPg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+			"integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
 			"cpu": [
 				"x64"
 			],
@@ -319,9 +332,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.12.tgz",
-			"integrity": "sha512-aVsENlr7B64w8I1lhHShND5o8cW6sB9n9MUtLumFlPhG3elhNWtE7M1TFpj3m7lT3sKQUMkGFjTQBrvDDO1YWA==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+			"integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
 			"cpu": [
 				"x64"
 			],
@@ -335,9 +348,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.12.tgz",
-			"integrity": "sha512-qbHGVQdKSwi0JQJuZznS4SyY27tYXYF0mrgthbxXrZI3AHKuRvU+Eqbg/F0rmLDpW/jkIZBlCO1XfHUBMNJ1pg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+			"integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
 			"cpu": [
 				"x64"
 			],
@@ -351,9 +364,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.12.tgz",
-			"integrity": "sha512-zsCp8Ql+96xXTVTmm6ffvoTSZSV2B/LzzkUXAY33F/76EajNw1m+jZ9zPfNJlJ3Rh4EzOszNDHsmG/fZOhtqDg==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+			"integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
 			"cpu": [
 				"arm64"
 			],
@@ -367,9 +380,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.12.tgz",
-			"integrity": "sha512-FfrFjR4id7wcFYOdqbDfDET3tjxCozUgbqdkOABsSFzoZGFC92UK7mg4JKRc/B3NNEf1s2WHxJ7VfTdVDPN3ng==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+			"integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
 			"cpu": [
 				"ia32"
 			],
@@ -383,9 +396,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.12.tgz",
-			"integrity": "sha512-JOOxw49BVZx2/5tW3FqkdjSD/5gXYeVGPDcB0lvap0gLQshkh1Nyel1QazC+wNxus3xPlsYAgqU1BUmrmCvWtw==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+			"integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
 			"cpu": [
 				"x64"
 			],
@@ -496,10 +509,45 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@jest/schemas": {
+			"version": "29.6.0",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
+			"integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+			"dev": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.27.8"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -556,6 +604,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.27.8",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"dev": true
+		},
 		"node_modules/@tsconfig/node10": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -581,9 +635,9 @@
 			"dev": true
 		},
 		"node_modules/@types/chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+			"integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
 			"dev": true
 		},
 		"node_modules/@types/chai-subset": {
@@ -813,43 +867,57 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@vitest/coverage-c8": {
-			"version": "0.29.7",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.29.7.tgz",
-			"integrity": "sha512-TSubtP9JFBuI/wuApxwknHe40VDkX8hFbBak0OXj4/jCeXrEu5B5GPWcxzyk9YvzXgCaDvoiZV79I7AvhNI9YQ==",
+		"node_modules/@vitest/coverage-v8": {
+			"version": "0.34.1",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.34.1.tgz",
+			"integrity": "sha512-lRgUwjTMr8idXEbUPSNH4jjRZJXJCVY3BqUa+LDXyJVe3pldxYMn/r0HMqatKUGTp0Kyf1j5LfFoY6kRqRp7jw==",
 			"dev": true,
 			"dependencies": {
-				"c8": "^7.13.0",
+				"@ampproject/remapping": "^2.2.1",
+				"@bcoe/v8-coverage": "^0.2.3",
+				"istanbul-lib-coverage": "^3.2.0",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-lib-source-maps": "^4.0.1",
+				"istanbul-reports": "^3.1.5",
+				"magic-string": "^0.30.1",
 				"picocolors": "^1.0.0",
-				"std-env": "^3.3.1"
+				"std-env": "^3.3.3",
+				"test-exclude": "^6.0.0",
+				"v8-to-istanbul": "^9.1.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/antfu"
+				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"vitest": ">=0.29.0 <1"
+				"vitest": ">=0.32.0 <1"
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "0.29.7",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.29.7.tgz",
-			"integrity": "sha512-UtG0tW0DP6b3N8aw7PHmweKDsvPv4wjGvrVZW7OSxaFg76ShtVdMiMcUkZJgCE8QWUmhwaM0aQhbbVLo4F4pkA==",
+			"version": "0.34.1",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.1.tgz",
+			"integrity": "sha512-q2CD8+XIsQ+tHwypnoCk8Mnv5e6afLFvinVGCq3/BOT4kQdVQmY6rRfyKkwcg635lbliLPqbunXZr+L1ssUWiQ==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/spy": "0.29.7",
-				"@vitest/utils": "0.29.7",
+				"@vitest/spy": "0.34.1",
+				"@vitest/utils": "0.34.1",
 				"chai": "^4.3.7"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "0.29.7",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.29.7.tgz",
-			"integrity": "sha512-Yt0+csM945+odOx4rjZSjibQfl2ymxqVsmYz6sO2fiO5RGPYDFCo60JF6tLL9pz4G/kjY4irUxadeB1XT+H1jg==",
+			"version": "0.34.1",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.1.tgz",
+			"integrity": "sha512-YfQMpYzDsYB7yqgmlxZ06NI4LurHWfrH7Wy3Pvf/z/vwUSgq1zLAb1lWcItCzQG+NVox+VvzlKQrYEXb47645g==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/utils": "0.29.7",
+				"@vitest/utils": "0.34.1",
 				"p-limit": "^4.0.0",
-				"pathe": "^1.1.0"
+				"pathe": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner/node_modules/p-limit": {
@@ -879,40 +947,50 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@vitest/spy": {
-			"version": "0.29.7",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.29.7.tgz",
-			"integrity": "sha512-IalL0iO6A6Xz8hthR8sctk6ZS//zVBX48EiNwQguYACdgdei9ZhwMaBFV70mpmeYAFCRAm+DpoFHM5470Im78A==",
+		"node_modules/@vitest/snapshot": {
+			"version": "0.34.1",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.1.tgz",
+			"integrity": "sha512-0O9LfLU0114OqdF8lENlrLsnn024Tb1CsS9UwG0YMWY2oGTQfPtkW+B/7ieyv0X9R2Oijhi3caB1xgGgEgclSQ==",
 			"dev": true,
 			"dependencies": {
-				"tinyspy": "^1.0.2"
+				"magic-string": "^0.30.1",
+				"pathe": "^1.1.1",
+				"pretty-format": "^29.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "0.34.1",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.1.tgz",
+			"integrity": "sha512-UT4WcI3EAPUNO8n6y9QoEqynGGEPmmRxC+cLzneFFXpmacivjHZsNbiKD88KUScv5DCHVDgdBsLD7O7s1enFcQ==",
+			"dev": true,
+			"dependencies": {
+				"tinyspy": "^2.1.1"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "0.29.7",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.29.7.tgz",
-			"integrity": "sha512-vNgGadp2eE5XKCXtZXL5UyNEDn68npSct75OC9AlELenSK0DiV1Mb9tfkwJHKjRb69iek+e79iipoJx8+s3SdA==",
+			"version": "0.34.1",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.1.tgz",
+			"integrity": "sha512-/ql9dsFi4iuEbiNcjNHQWXBum7aL8pyhxvfnD9gNtbjR9fUKAjxhj4AA3yfLXg6gJpMGGecvtF8Au2G9y3q47Q==",
 			"dev": true,
 			"dependencies": {
-				"cli-truncate": "^3.1.0",
-				"diff": "^5.1.0",
+				"diff-sequences": "^29.4.3",
 				"loupe": "^2.3.6",
-				"pretty-format": "^27.5.1"
-			}
-		},
-		"node_modules/@vitest/utils/node_modules/diff": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-			"integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.3.1"
+				"pretty-format": "^29.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.8.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-			"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1123,32 +1201,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/c8": {
-			"version": "7.13.0",
-			"resolved": "https://registry.npmjs.org/c8/-/c8-7.13.0.tgz",
-			"integrity": "sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==",
-			"dev": true,
-			"dependencies": {
-				"@bcoe/v8-coverage": "^0.2.3",
-				"@istanbuljs/schema": "^0.1.3",
-				"find-up": "^5.0.0",
-				"foreground-child": "^2.0.0",
-				"istanbul-lib-coverage": "^3.2.0",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-reports": "^3.1.4",
-				"rimraf": "^3.0.2",
-				"test-exclude": "^6.0.0",
-				"v8-to-istanbul": "^9.0.0",
-				"yargs": "^16.2.0",
-				"yargs-parser": "^20.2.9"
-			},
-			"bin": {
-				"c8": "bin/c8.js"
-			},
-			"engines": {
-				"node": ">=10.12.0"
-			}
-		},
 		"node_modules/cac": {
 			"version": "6.7.14",
 			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1221,62 +1273,6 @@
 			"dev": true,
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/cli-truncate": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
-			"integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
-			"dev": true,
-			"dependencies": {
-				"slice-ansi": "^5.0.0",
-				"string-width": "^5.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"node_modules/cliui/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
-		},
-		"node_modules/cliui/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cliui/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/color-convert": {
@@ -1389,6 +1385,15 @@
 				"node": ">=0.3.1"
 			}
 		},
+		"node_modules/diff-sequences": {
+			"version": "29.4.3",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+			"integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+			"dev": true,
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1412,18 +1417,6 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
-		},
-		"node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-			"dev": true
-		},
-		"node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"dev": true
 		},
 		"node_modules/es-abstract": {
 			"version": "1.21.2",
@@ -1514,9 +1507,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.12.tgz",
-			"integrity": "sha512-bX/zHl7Gn2CpQwcMtRogTTBf9l1nl+H6R8nUbjk+RuKqAE3+8FDulLA+pHvX7aA7Xe07Iwa+CWvy9I8Y2qqPKQ==",
+			"version": "0.18.20",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+			"integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1526,37 +1519,28 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.17.12",
-				"@esbuild/android-arm64": "0.17.12",
-				"@esbuild/android-x64": "0.17.12",
-				"@esbuild/darwin-arm64": "0.17.12",
-				"@esbuild/darwin-x64": "0.17.12",
-				"@esbuild/freebsd-arm64": "0.17.12",
-				"@esbuild/freebsd-x64": "0.17.12",
-				"@esbuild/linux-arm": "0.17.12",
-				"@esbuild/linux-arm64": "0.17.12",
-				"@esbuild/linux-ia32": "0.17.12",
-				"@esbuild/linux-loong64": "0.17.12",
-				"@esbuild/linux-mips64el": "0.17.12",
-				"@esbuild/linux-ppc64": "0.17.12",
-				"@esbuild/linux-riscv64": "0.17.12",
-				"@esbuild/linux-s390x": "0.17.12",
-				"@esbuild/linux-x64": "0.17.12",
-				"@esbuild/netbsd-x64": "0.17.12",
-				"@esbuild/openbsd-x64": "0.17.12",
-				"@esbuild/sunos-x64": "0.17.12",
-				"@esbuild/win32-arm64": "0.17.12",
-				"@esbuild/win32-ia32": "0.17.12",
-				"@esbuild/win32-x64": "0.17.12"
-			}
-		},
-		"node_modules/escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
+				"@esbuild/android-arm": "0.18.20",
+				"@esbuild/android-arm64": "0.18.20",
+				"@esbuild/android-x64": "0.18.20",
+				"@esbuild/darwin-arm64": "0.18.20",
+				"@esbuild/darwin-x64": "0.18.20",
+				"@esbuild/freebsd-arm64": "0.18.20",
+				"@esbuild/freebsd-x64": "0.18.20",
+				"@esbuild/linux-arm": "0.18.20",
+				"@esbuild/linux-arm64": "0.18.20",
+				"@esbuild/linux-ia32": "0.18.20",
+				"@esbuild/linux-loong64": "0.18.20",
+				"@esbuild/linux-mips64el": "0.18.20",
+				"@esbuild/linux-ppc64": "0.18.20",
+				"@esbuild/linux-riscv64": "0.18.20",
+				"@esbuild/linux-s390x": "0.18.20",
+				"@esbuild/linux-x64": "0.18.20",
+				"@esbuild/netbsd-x64": "0.18.20",
+				"@esbuild/openbsd-x64": "0.18.20",
+				"@esbuild/sunos-x64": "0.18.20",
+				"@esbuild/win32-arm64": "0.18.20",
+				"@esbuild/win32-ia32": "0.18.20",
+				"@esbuild/win32-x64": "0.18.20"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2011,19 +1995,6 @@
 				"is-callable": "^1.1.3"
 			}
 		},
-		"node_modules/foreground-child": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-			"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
-			"dev": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2075,15 +2046,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-caller-file": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true,
-			"engines": {
-				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/get-func-name": {
@@ -2466,18 +2428,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-fullwidth-code-point": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-			"integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2640,23 +2590,37 @@
 			}
 		},
 		"node_modules/istanbul-lib-report": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-			"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
 			"dev": true,
 			"dependencies": {
 				"istanbul-lib-coverage": "^3.0.0",
-				"make-dir": "^3.0.0",
+				"make-dir": "^4.0.0",
 				"supports-color": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-source-maps": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0",
+				"source-map": "^0.6.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/istanbul-reports": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-			"integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+			"integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
 			"dev": true,
 			"dependencies": {
 				"html-escaper": "^2.0.0",
@@ -2791,28 +2755,37 @@
 			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
 			"dev": true
 		},
-		"node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+		"node_modules/magic-string": {
+			"version": "0.30.2",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
+			"integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
 			"dev": true,
 			"dependencies": {
-				"semver": "^6.0.0"
+				"@jridgewell/sourcemap-codec": "^1.4.15"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			}
+		},
+		"node_modules/magic-string/node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+			"dev": true
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/make-dir/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/make-error": {
@@ -2877,15 +2850,15 @@
 			}
 		},
 		"node_modules/mlly": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.0.tgz",
-			"integrity": "sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.0.tgz",
+			"integrity": "sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==",
 			"dev": true,
 			"dependencies": {
-				"acorn": "^8.8.2",
-				"pathe": "^1.1.0",
-				"pkg-types": "^1.0.2",
-				"ufo": "^1.1.1"
+				"acorn": "^8.9.0",
+				"pathe": "^1.1.1",
+				"pkg-types": "^1.0.3",
+				"ufo": "^1.1.2"
 			}
 		},
 		"node_modules/ms": {
@@ -2895,10 +2868,16 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -3082,9 +3061,9 @@
 			}
 		},
 		"node_modules/pathe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-			"integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
+			"integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==",
 			"dev": true
 		},
 		"node_modules/pathval": {
@@ -3115,20 +3094,20 @@
 			}
 		},
 		"node_modules/pkg-types": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.2.tgz",
-			"integrity": "sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+			"integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
 			"dev": true,
 			"dependencies": {
 				"jsonc-parser": "^3.2.0",
-				"mlly": "^1.1.1",
+				"mlly": "^1.2.0",
 				"pathe": "^1.1.0"
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.21",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-			"integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+			"version": "8.4.27",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
+			"integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3138,10 +3117,14 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.4",
+				"nanoid": "^3.3.6",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
@@ -3194,17 +3177,17 @@
 			}
 		},
 		"node_modules/pretty-format": {
-			"version": "27.5.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"version": "29.6.2",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
+			"integrity": "sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==",
 			"dev": true,
 			"dependencies": {
-				"ansi-regex": "^5.0.1",
+				"@jest/schemas": "^29.6.0",
 				"ansi-styles": "^5.0.0",
-				"react-is": "^17.0.1"
+				"react-is": "^18.0.0"
 			},
 			"engines": {
-				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/pretty-format/node_modules/ansi-styles": {
@@ -3265,9 +3248,9 @@
 			]
 		},
 		"node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"version": "18.2.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
 		},
 		"node_modules/regexp.prototype.flags": {
@@ -3285,15 +3268,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve": {
@@ -3348,9 +3322,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "3.20.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.0.tgz",
-			"integrity": "sha512-YsIfrk80NqUDrxrjWPXUa7PWvAfegZEXHuPsEZg58fGCdjL1I9C1i/NaG+L+27kxxwkrG/QEDEQc8s/ynXWWGQ==",
+			"version": "3.28.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
+			"integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -3401,9 +3375,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -3468,12 +3442,6 @@
 			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
 			"dev": true
 		},
-		"node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true
-		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3481,34 +3449,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/slice-ansi": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-			"integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^6.0.0",
-				"is-fullwidth-code-point": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
-		},
-		"node_modules/slice-ansi/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/source-map": {
@@ -3536,54 +3476,10 @@
 			"dev": true
 		},
 		"node_modules/std-env": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.2.tgz",
-			"integrity": "sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.3.tgz",
+			"integrity": "sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==",
 			"dev": true
-		},
-		"node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"dev": true,
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/string-width/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/string-width/node_modules/strip-ansi": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-			"integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
 		},
 		"node_modules/string.prototype.trim": {
 			"version": "1.2.7",
@@ -3720,24 +3616,24 @@
 			"dev": true
 		},
 		"node_modules/tinybench": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.4.0.tgz",
-			"integrity": "sha512-iyziEiyFxX4kyxSp+MtY1oCH/lvjH3PxFN8PGCDeqcZWAJ/i+9y+nL85w99PxVzrIvew/GSkSbDYtiGVa85Afg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
+			"integrity": "sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==",
 			"dev": true
 		},
 		"node_modules/tinypool": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.4.0.tgz",
-			"integrity": "sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.7.0.tgz",
+			"integrity": "sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/tinyspy": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.1.1.tgz",
-			"integrity": "sha512-UVq5AXt/gQlti7oxoIg5oi/9r0WpF7DGEVwXgqWSMmyN16+e3tl5lIvTaOpJ3TAtu5xFzWccFRM4R5NaWHF+4g==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
+			"integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
@@ -3937,9 +3833,9 @@
 			}
 		},
 		"node_modules/ufo": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
-			"integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.2.0.tgz",
+			"integrity": "sha512-RsPyTbqORDNDxqAdQPQBpgqhWle1VcTSou/FraClYlHf6TZnQcGslpLcAphNR+sQW4q5lLWLbOsRlh9j24baQg==",
 			"dev": true
 		},
 		"node_modules/unbox-primitive": {
@@ -3987,25 +3883,24 @@
 			}
 		},
 		"node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"version": "0.3.19",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+			"integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.2.1.tgz",
-			"integrity": "sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==",
+			"version": "4.4.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
+			"integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.17.5",
-				"postcss": "^8.4.21",
-				"resolve": "^1.22.1",
-				"rollup": "^3.18.0"
+				"esbuild": "^0.18.10",
+				"postcss": "^8.4.27",
+				"rollup": "^3.27.1"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -4013,12 +3908,16 @@
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
 			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
 				"@types/node": ">= 14",
 				"less": "*",
+				"lightningcss": "^1.21.0",
 				"sass": "*",
 				"stylus": "*",
 				"sugarss": "*",
@@ -4029,6 +3928,9 @@
 					"optional": true
 				},
 				"less": {
+					"optional": true
+				},
+				"lightningcss": {
 					"optional": true
 				},
 				"sass": {
@@ -4046,15 +3948,15 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "0.29.7",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.29.7.tgz",
-			"integrity": "sha512-PakCZLvz37yFfUPWBnLa1OYHPCGm5v4pmRrTcFN4V/N/T3I6tyP3z07S//9w+DdeL7vVd0VSeyMZuAh+449ZWw==",
+			"version": "0.34.1",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.1.tgz",
+			"integrity": "sha512-odAZAL9xFMuAg8aWd7nSPT+hU8u2r9gU3LRm9QKjxBEF2rRdWpMuqkrkjvyVQEdNFiBctqr2Gg4uJYizm5Le6w==",
 			"dev": true,
 			"dependencies": {
 				"cac": "^6.7.14",
 				"debug": "^4.3.4",
-				"mlly": "^1.1.0",
-				"pathe": "^1.1.0",
+				"mlly": "^1.4.0",
+				"pathe": "^1.1.1",
 				"picocolors": "^1.0.0",
 				"vite": "^3.0.0 || ^4.0.0"
 			},
@@ -4062,58 +3964,61 @@
 				"vite-node": "vite-node.mjs"
 			},
 			"engines": {
-				"node": ">=v14.16.0"
+				"node": ">=v14.18.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/antfu"
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/vitest": {
-			"version": "0.29.7",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.29.7.tgz",
-			"integrity": "sha512-aWinOSOu4jwTuZHkb+cCyrqQ116Q9TXaJrNKTHudKBknIpR0VplzeaOUuDF9jeZcrbtQKZQt6yrtd+eakbaxHg==",
+			"version": "0.34.1",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.1.tgz",
+			"integrity": "sha512-G1PzuBEq9A75XSU88yO5G4vPT20UovbC/2osB2KEuV/FisSIIsw7m5y2xMdB7RsAGHAfg2lPmp2qKr3KWliVlQ==",
 			"dev": true,
 			"dependencies": {
-				"@types/chai": "^4.3.4",
+				"@types/chai": "^4.3.5",
 				"@types/chai-subset": "^1.3.3",
 				"@types/node": "*",
-				"@vitest/expect": "0.29.7",
-				"@vitest/runner": "0.29.7",
-				"@vitest/spy": "0.29.7",
-				"@vitest/utils": "0.29.7",
-				"acorn": "^8.8.1",
+				"@vitest/expect": "0.34.1",
+				"@vitest/runner": "0.34.1",
+				"@vitest/snapshot": "0.34.1",
+				"@vitest/spy": "0.34.1",
+				"@vitest/utils": "0.34.1",
+				"acorn": "^8.9.0",
 				"acorn-walk": "^8.2.0",
 				"cac": "^6.7.14",
 				"chai": "^4.3.7",
 				"debug": "^4.3.4",
-				"local-pkg": "^0.4.2",
-				"pathe": "^1.1.0",
+				"local-pkg": "^0.4.3",
+				"magic-string": "^0.30.1",
+				"pathe": "^1.1.1",
 				"picocolors": "^1.0.0",
-				"source-map": "^0.6.1",
-				"std-env": "^3.3.1",
-				"strip-literal": "^1.0.0",
-				"tinybench": "^2.3.1",
-				"tinypool": "^0.4.0",
-				"tinyspy": "^1.0.2",
+				"std-env": "^3.3.3",
+				"strip-literal": "^1.0.1",
+				"tinybench": "^2.5.0",
+				"tinypool": "^0.7.0",
 				"vite": "^3.0.0 || ^4.0.0",
-				"vite-node": "0.29.7",
+				"vite-node": "0.34.1",
 				"why-is-node-running": "^2.2.2"
 			},
 			"bin": {
 				"vitest": "vitest.mjs"
 			},
 			"engines": {
-				"node": ">=v14.16.0"
+				"node": ">=v14.18.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/antfu"
+				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
 				"@vitest/browser": "*",
 				"@vitest/ui": "*",
 				"happy-dom": "*",
-				"jsdom": "*"
+				"jsdom": "*",
+				"playwright": "*",
+				"safaridriver": "*",
+				"webdriverio": "*"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
@@ -4129,6 +4034,9 @@
 					"optional": true
 				},
 				"jsdom": {
+					"optional": true
+				},
+				"playwright": {
 					"optional": true
 				},
 				"safaridriver": {
@@ -4227,128 +4135,17 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
-		},
-		"node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
 		},
-		"node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/yargs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
-		},
-		"node_modules/yargs/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/yargs/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/yn": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^5.55.0",
 		"@typescript-eslint/parser": "^5.55.0",
-		"@vitest/coverage-c8": "^0.29.3",
+		"@vitest/coverage-v8": "^0.34.1",
 		"eslint": "^8.36.0",
 		"eslint-config-prettier": "^8.8.0",
 		"eslint-plugin-import": "^2.27.5",
@@ -75,7 +75,7 @@
 		"ts-node": "^10.9.1",
 		"typedoc": "0.23.28",
 		"typescript": "~5.0",
-		"vitest": "^0.29.3"
+		"vitest": "^0.34.1"
 	},
 	"volta": {
 		"node": "18.12.1",

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -324,6 +324,7 @@ export function ieqBy<T>(
 ): boolean {
 	const lhsIter = lhs[Symbol.iterator]();
 	const rhsIter = rhs[Symbol.iterator]();
+	let result = false;
 
 	for (
 		let lhsNxt = lhsIter.next(), rhsNxt = rhsIter.next();
@@ -331,15 +332,17 @@ export function ieqBy<T>(
 		lhsNxt = lhsIter.next(), rhsNxt = rhsIter.next()
 	) {
 		if (lhsNxt.done) {
-			return !!rhsNxt.done;
+			result = !!rhsNxt.done;
+			break;
 		}
 		if (rhsNxt.done) {
-			return false;
+			break;
 		}
 		if (!eqBy(lhsNxt.value, rhsNxt.value)) {
-			return false;
+			break;
 		}
 	}
+	return result;
 }
 
 /**
@@ -683,6 +686,7 @@ export function icmpBy<T>(
 ): Ordering {
 	const lhsIter = lhs[Symbol.iterator]();
 	const rhsIter = rhs[Symbol.iterator]();
+	let result: Ordering;
 
 	for (
 		let lhsNxt = lhsIter.next(), rhsNxt = rhsIter.next();
@@ -690,16 +694,20 @@ export function icmpBy<T>(
 		lhsNxt = lhsIter.next(), rhsNxt = rhsIter.next()
 	) {
 		if (lhsNxt.done) {
-			return rhsNxt.done ? Ordering.equal : Ordering.less;
+			result = rhsNxt.done ? Ordering.equal : Ordering.less;
+			break;
 		}
 		if (rhsNxt.done) {
-			return Ordering.greater;
+			result = Ordering.greater;
+			break;
 		}
 		const ordering = cmpBy(lhsNxt.value, rhsNxt.value);
 		if (ordering.isNe()) {
-			return ordering;
+			result = ordering;
+			break;
 		}
 	}
+	return result;
 }
 
 /**


### PR DESCRIPTION
- Replace c8 with v8 as the test coverage provider
- Adjust the implementations of `ieqBy` and `icmpBy` to achieve 100% test coverage