### PR TITLE
Updgrade the libraries and rules for linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,21 +6,26 @@
 	},
 	"extends": [
 		"eslint:recommended",
-		"plugin:@typescript-eslint/recommended",
+		"plugin:@typescript-eslint/strict-type-checked",
+		"plugin:@typescript-eslint/stylistic-type-checked",
 		"prettier"
 	],
 	"ignorePatterns": ["dist"],
 	"parser": "@typescript-eslint/parser",
 	"parserOptions": {
 		"ecmaVersion": "latest",
+		"project": "./tsconfig.json",
 		"sourceType": "module"
 	},
 	"plugins": ["@typescript-eslint"],
+	"root": true,
 	"rules": {
+		"@typescript-eslint/consistent-generic-constructors": "off",
 		"@typescript-eslint/consistent-type-imports": "error",
 		"@typescript-eslint/no-explicit-any": "off",
 		"@typescript-eslint/no-import-type-side-effects": "error",
 		"@typescript-eslint/no-namespace": "off",
+		"@typescript-eslint/require-await": "off",
 		"no-inner-declarations": "off",
 		"quotes": ["error", "double"],
 		"semi": ["error", "always"]

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,7 @@
 {
 	"trailingComma": "all",
-	"tabWidth": 4,
 	"useTabs": true,
+	"tabWidth": 4,
 	"overrides": [
 		{
 			"files": ["*.yaml", "*.yml"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
 			"version": "0.9.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
-				"@typescript-eslint/eslint-plugin": "^5.55.0",
-				"@typescript-eslint/parser": "^5.55.0",
+				"@typescript-eslint/eslint-plugin": "^6.4.1",
+				"@typescript-eslint/parser": "^6.4.1",
 				"@vitest/coverage-v8": "^0.34.1",
-				"eslint": "^8.36.0",
-				"eslint-config-prettier": "^8.8.0",
-				"eslint-plugin-import": "^2.27.5",
+				"eslint": "^8.47.0",
+				"eslint-config-prettier": "^9.0.0",
+				"eslint-plugin-import": "^2.28.1",
 				"fast-check": "^3.7.1",
 				"prettier": "2.8.6",
 				"prettier-plugin-organize-imports": "^3.2.2",
@@ -26,6 +26,15 @@
 			},
 			"engines": {
 				"node": "16.* || >= 18.*"
+			}
+		},
+		"node_modules/@aashutoshrathi/word-wrap": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -412,9 +421,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz",
-			"integrity": "sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
 			"dev": true,
 			"dependencies": {
 				"eslint-visitor-keys": "^3.3.0"
@@ -427,23 +436,23 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz",
-			"integrity": "sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+			"integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
 			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
-			"integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+			"integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.5.0",
+				"espree": "^9.6.0",
 				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -459,18 +468,18 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
-			"integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
+			"integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.8",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-			"integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+			"integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
 			"dev": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
@@ -656,9 +665,9 @@
 			"dev": true
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.11",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+			"version": "7.0.12",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
 			"dev": true
 		},
 		"node_modules/@types/json5": {
@@ -674,38 +683,39 @@
 			"dev": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.3.13",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.56.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz",
-			"integrity": "sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.1.tgz",
+			"integrity": "sha512-3F5PtBzUW0dYlq77Lcqo13fv+58KDwUib3BddilE8ajPJT+faGgxmI9Sw+I8ZS22BYwoir9ZhNXcLi+S+I2bkw==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.56.0",
-				"@typescript-eslint/type-utils": "5.56.0",
-				"@typescript-eslint/utils": "5.56.0",
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.4.1",
+				"@typescript-eslint/type-utils": "6.4.1",
+				"@typescript-eslint/utils": "6.4.1",
+				"@typescript-eslint/visitor-keys": "6.4.1",
 				"debug": "^4.3.4",
-				"grapheme-splitter": "^1.0.4",
-				"ignore": "^5.2.0",
-				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -714,25 +724,26 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.56.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz",
-			"integrity": "sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.1.tgz",
+			"integrity": "sha512-610G6KHymg9V7EqOaNBMtD1GgpAmGROsmfHJPXNLCU9bfIuLrkdOygltK784F6Crboyd5tBFayPB7Sf0McrQwg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.56.0",
-				"@typescript-eslint/types": "5.56.0",
-				"@typescript-eslint/typescript-estree": "5.56.0",
+				"@typescript-eslint/scope-manager": "6.4.1",
+				"@typescript-eslint/types": "6.4.1",
+				"@typescript-eslint/typescript-estree": "6.4.1",
+				"@typescript-eslint/visitor-keys": "6.4.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -741,16 +752,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.56.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz",
-			"integrity": "sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.1.tgz",
+			"integrity": "sha512-p/OavqOQfm4/Hdrr7kvacOSFjwQ2rrDVJRPxt/o0TOWdFnjJptnjnZ+sYDR7fi4OimvIuKp+2LCkc+rt9fIW+A==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.56.0",
-				"@typescript-eslint/visitor-keys": "5.56.0"
+				"@typescript-eslint/types": "6.4.1",
+				"@typescript-eslint/visitor-keys": "6.4.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -758,25 +769,25 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.56.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz",
-			"integrity": "sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.1.tgz",
+			"integrity": "sha512-7ON8M8NXh73SGZ5XvIqWHjgX2f+vvaOarNliGhjrJnv1vdjG0LVIz+ToYfPirOoBi56jxAKLfsLm40+RvxVVXA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.56.0",
-				"@typescript-eslint/utils": "5.56.0",
+				"@typescript-eslint/typescript-estree": "6.4.1",
+				"@typescript-eslint/utils": "6.4.1",
 				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "*"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -785,12 +796,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.56.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.56.0.tgz",
-			"integrity": "sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
+			"integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
 			"dev": true,
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -798,21 +809,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.56.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz",
-			"integrity": "sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.1.tgz",
+			"integrity": "sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.56.0",
-				"@typescript-eslint/visitor-keys": "5.56.0",
+				"@typescript-eslint/types": "6.4.1",
+				"@typescript-eslint/visitor-keys": "6.4.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -825,42 +836,41 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.56.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.56.0.tgz",
-			"integrity": "sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.1.tgz",
+			"integrity": "sha512-F/6r2RieNeorU0zhqZNv89s9bDZSovv3bZQpUNOmmQK1L80/cV4KEu95YUJWi75u5PhboFoKUJBnZ4FQcoqhDw==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.56.0",
-				"@typescript-eslint/types": "5.56.0",
-				"@typescript-eslint/typescript-estree": "5.56.0",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.3.7"
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.4.1",
+				"@typescript-eslint/types": "6.4.1",
+				"@typescript-eslint/typescript-estree": "6.4.1",
+				"semver": "^7.5.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.56.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz",
-			"integrity": "sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.1.tgz",
+			"integrity": "sha512-y/TyRJsbZPkJIZQXrHfdnxVnxyKegnpEvnRGNam7s3TRR2ykGefEWOhaef00/UUN3IZxizS7BTO3svd3lCOJRQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.56.0",
-				"eslint-visitor-keys": "^3.3.0"
+				"@typescript-eslint/types": "6.4.1",
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1114,6 +1124,25 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/array.prototype.findlastindex": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.2.tgz",
+			"integrity": "sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
+				"es-shim-unscopables": "^1.0.0",
+				"get-intrinsic": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/array.prototype.flat": {
@@ -1556,27 +1585,27 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
-			"integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
+			"integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
-				"@eslint-community/regexpp": "^4.4.0",
-				"@eslint/eslintrc": "^2.0.1",
-				"@eslint/js": "8.36.0",
-				"@humanwhocodes/config-array": "^0.11.8",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.2",
+				"@eslint/js": "^8.47.0",
+				"@humanwhocodes/config-array": "^0.11.10",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
-				"ajv": "^6.10.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.1.1",
-				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.5.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -1584,22 +1613,19 @@
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
 				"globals": "^13.19.0",
-				"grapheme-splitter": "^1.0.4",
+				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
-				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
-				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.1",
+				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
 			},
 			"bin": {
@@ -1613,9 +1639,9 @@
 			}
 		},
 		"node_modules/eslint-config-prettier": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-			"integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+			"integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
 			"dev": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
@@ -1645,9 +1671,9 @@
 			}
 		},
 		"node_modules/eslint-module-utils": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
-			"integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
+			"integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^3.2.7"
@@ -1671,26 +1697,28 @@
 			}
 		},
 		"node_modules/eslint-plugin-import": {
-			"version": "2.27.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
-			"integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+			"version": "2.28.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
+			"integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
 			"dev": true,
 			"dependencies": {
 				"array-includes": "^3.1.6",
+				"array.prototype.findlastindex": "^1.2.2",
 				"array.prototype.flat": "^1.3.1",
 				"array.prototype.flatmap": "^1.3.1",
 				"debug": "^3.2.7",
 				"doctrine": "^2.1.0",
 				"eslint-import-resolver-node": "^0.3.7",
-				"eslint-module-utils": "^2.7.4",
+				"eslint-module-utils": "^2.8.0",
 				"has": "^1.0.3",
-				"is-core-module": "^2.11.0",
+				"is-core-module": "^2.13.0",
 				"is-glob": "^4.0.3",
 				"minimatch": "^3.1.2",
+				"object.fromentries": "^2.0.6",
+				"object.groupby": "^1.0.0",
 				"object.values": "^1.1.6",
-				"resolve": "^1.22.1",
-				"semver": "^6.3.0",
-				"tsconfig-paths": "^3.14.1"
+				"semver": "^6.3.1",
+				"tsconfig-paths": "^3.14.2"
 			},
 			"engines": {
 				"node": ">=4"
@@ -1721,40 +1749,18 @@
 			}
 		},
 		"node_modules/eslint-plugin-import/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"dev": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/eslint-visitor-keys": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-			"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
@@ -1762,26 +1768,32 @@
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+		"node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
 			"engines": {
-				"node": ">=4.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.5.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
-			"integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
 			"dependencies": {
-				"acorn": "^8.8.0",
+				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1802,15 +1814,6 @@
 				"node": ">=0.10"
 			}
 		},
-		"node_modules/esquery/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/esrecurse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -1823,19 +1826,10 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/esrecurse/node_modules/estraverse": {
+		"node_modules/estraverse": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true,
 			"engines": {
 				"node": ">=4.0"
@@ -1879,9 +1873,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.12",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -2058,13 +2052,14 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-			"integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+			"integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
 			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
+				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3"
 			},
 			"funding": {
@@ -2120,9 +2115,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.20.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+			"version": "13.21.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+			"integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -2181,10 +2176,10 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+		"node_modules/graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
 		},
 		"node_modules/has": {
@@ -2393,9 +2388,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+			"integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -2628,16 +2623,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/js-sdsl": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
-			"integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
-			"dev": true,
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/js-sdsl"
 			}
 		},
 		"node_modules/js-yaml": {
@@ -2891,12 +2876,6 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
-		"node_modules/natural-compare-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-			"dev": true
-		},
 		"node_modules/object-inspect": {
 			"version": "1.12.3",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -2933,6 +2912,35 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/object.fromentries": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+			"integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.groupby": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
+			"integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.21.2",
+				"get-intrinsic": "^1.2.1"
+			}
+		},
 		"node_modules/object.values": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
@@ -2960,17 +2968,17 @@
 			}
 		},
 		"node_modules/optionator": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+			"integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
 			"dev": true,
 			"dependencies": {
+				"@aashutoshrathi/word-wrap": "^1.2.3",
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
-				"type-check": "^0.4.0",
-				"word-wrap": "^1.2.3"
+				"type-check": "^0.4.0"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -3651,6 +3659,18 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/ts-api-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+			"integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.13.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
+			}
+		},
 		"node_modules/ts-node": {
 			"version": "10.9.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -3704,27 +3724,6 @@
 				"json5": "^1.0.2",
 				"minimist": "^1.2.6",
 				"strip-bom": "^3.0.0"
-			}
-		},
-		"node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
-		},
-		"node_modules/tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^1.8.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
 			}
 		},
 		"node_modules/type-check": {
@@ -4124,15 +4123,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -62,12 +62,12 @@
 		"postpublish": "npm run clean"
 	},
 	"devDependencies": {
-		"@typescript-eslint/eslint-plugin": "^5.55.0",
-		"@typescript-eslint/parser": "^5.55.0",
+		"@typescript-eslint/eslint-plugin": "^6.4.1",
+		"@typescript-eslint/parser": "^6.4.1",
 		"@vitest/coverage-v8": "^0.34.1",
-		"eslint": "^8.36.0",
-		"eslint-config-prettier": "^8.8.0",
-		"eslint-plugin-import": "^2.27.5",
+		"eslint": "^8.47.0",
+		"eslint-config-prettier": "^9.0.0",
+		"eslint-plugin-import": "^2.28.1",
 		"fast-check": "^3.7.1",
 		"prettier": "2.8.6",
 		"prettier-plugin-organize-imports": "^3.2.2",

--- a/src/builder.test.ts
+++ b/src/builder.test.ts
@@ -150,7 +150,7 @@ describe("SemigroupCmbBuilder", () => {
 
 describe("NoOpBuilder", () => {
 	it("does not build anything and ignores all elements", () => {
-		const builder: Builder<unknown, void> = new NoOpBuilder();
+		const builder: Builder<unknown, unknown> = new NoOpBuilder();
 		builder.add(1);
 		builder.add(2);
 		const output = builder.finish();

--- a/src/either.ts
+++ b/src/either.ts
@@ -132,7 +132,7 @@ export namespace Either {
 			} else {
 				halted = true;
 				err = either.val;
-				nxt = gen.return(undefined as any);
+				nxt = gen.return(undefined as never);
 			}
 		}
 		return halted ? left(err) : right(nxt.value);
@@ -476,7 +476,7 @@ export namespace Either {
 			this.val = val;
 		}
 
-		*[Symbol.iterator](): Generator<Either<A, never>, never, unknown> {
+		*[Symbol.iterator](): Generator<Either<A, never>, never> {
 			return (yield this) as never;
 		}
 	}
@@ -493,17 +493,13 @@ export namespace Either {
 			this.val = val;
 		}
 
-		*[Symbol.iterator](): Generator<Either<never, B>, B, unknown> {
+		*[Symbol.iterator](): Generator<Either<never, B>, B> {
 			return (yield this) as B;
 		}
 	}
 
 	/** A generator that yields `Either` and returns a value. */
-	export type Go<E, TReturn> = Generator<
-		Either<E, unknown>,
-		TReturn,
-		unknown
-	>;
+	export type Go<E, TReturn> = Generator<Either<E, unknown>, TReturn>;
 
 	/** Extract the `Left` value type `A` from the type `Either<A, B>`. */
 	export type LeftT<TEither extends Either<any, any>> = [TEither] extends [
@@ -552,7 +548,7 @@ export namespace AsyncEither {
 			} else {
 				halted = true;
 				err = either.val;
-				nxt = await gen.return(undefined as any);
+				nxt = await gen.return(undefined as never);
 			}
 		}
 		return halted ? Either.left(err) : Either.right(nxt.value);
@@ -856,9 +852,5 @@ export namespace AsyncEither {
 	}
 
 	/** An async generator that yields `Either` and returns a value. */
-	export type Go<E, TReturn> = AsyncGenerator<
-		Either<E, any>,
-		TReturn,
-		unknown
-	>;
+	export type Go<E, TReturn> = AsyncGenerator<Either<E, unknown>, TReturn>;
 }

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -170,12 +170,13 @@ export namespace Ior {
 				} else {
 					acc = cmb(acc, ior.val);
 				}
-				nxt = gen.return(undefined as any);
+				nxt = gen.return(undefined as never);
 			}
 		}
 
 		if (halted) {
-			return left(acc as A);
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			return left(acc!);
 		}
 		if (acc === undefined) {
 			return right(nxt.value);
@@ -595,7 +596,7 @@ export namespace Ior {
 			this.val = val;
 		}
 
-		*[Symbol.iterator](): Generator<Ior<A, never>, never, unknown> {
+		*[Symbol.iterator](): Generator<Ior<A, never>, never> {
 			return (yield this) as never;
 		}
 	}
@@ -612,7 +613,7 @@ export namespace Ior {
 			this.val = val;
 		}
 
-		*[Symbol.iterator](): Generator<Ior<never, B>, B, unknown> {
+		*[Symbol.iterator](): Generator<Ior<never, B>, B> {
 			return (yield this) as B;
 		}
 	}
@@ -640,7 +641,7 @@ export namespace Ior {
 			this.snd = snd;
 		}
 
-		*[Symbol.iterator](): Generator<Ior<A, B>, B, unknown> {
+		*[Symbol.iterator](): Generator<Ior<A, B>, B> {
 			return (yield this) as B;
 		}
 	}
@@ -648,8 +649,7 @@ export namespace Ior {
 	/** A generator that yields `Ior` and returns a value. */
 	export type Go<A extends Semigroup<A>, TReturn> = Generator<
 		Ior<A, unknown>,
-		TReturn,
-		unknown
+		TReturn
 	>;
 
 	/** Extract the left-hand value type `A` from the type `Ior<A, B>`. */
@@ -709,12 +709,13 @@ export namespace AsyncIor {
 				} else {
 					acc = cmb(acc, ior.val);
 				}
-				nxt = await gen.return(undefined as any);
+				nxt = await gen.return(undefined as never);
 			}
 		}
 
 		if (halted) {
-			return Ior.left(acc as A);
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			return Ior.left(acc!);
 		}
 		if (acc === undefined) {
 			return Ior.right(nxt.value);
@@ -1033,7 +1034,6 @@ export namespace AsyncIor {
 	/** An async generator that yields `Ior` and returns a value. */
 	export type Go<A extends Semigroup<A>, TReturn> = AsyncGenerator<
 		Ior<A, unknown>,
-		TReturn,
-		unknown
+		TReturn
 	>;
 }

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -145,7 +145,7 @@ export namespace Maybe {
 				nxt = gen.next(maybe.val);
 			} else {
 				halted = true;
-				nxt = gen.return(undefined as any);
+				nxt = gen.return(undefined as never);
 			}
 		}
 		return halted ? nothing : just(nxt.value);
@@ -516,7 +516,7 @@ export namespace Maybe {
 			super();
 		}
 
-		*[Symbol.iterator](): Generator<Maybe<never>, never, unknown> {
+		*[Symbol.iterator](): Generator<Maybe<never>, never> {
 			return (yield this) as never;
 		}
 	}
@@ -533,7 +533,7 @@ export namespace Maybe {
 			this.val = val;
 		}
 
-		*[Symbol.iterator](): Generator<Maybe<T>, T, unknown> {
+		*[Symbol.iterator](): Generator<Maybe<T>, T> {
 			return (yield this) as T;
 		}
 	}
@@ -542,7 +542,7 @@ export namespace Maybe {
 	export const nothing = Maybe.Nothing.singleton as Maybe<never>;
 
 	/** A generator that yields `Maybe` and returns a value. */
-	export type Go<TReturn> = Generator<Maybe<unknown>, TReturn, unknown>;
+	export type Go<TReturn> = Generator<Maybe<unknown>, TReturn>;
 
 	/** Extract the `Just` value type `T` from the type `Maybe<T>`. */
 	export type JustT<TMaybe extends Maybe<any>> = TMaybe extends Maybe<infer T>
@@ -580,7 +580,7 @@ export namespace AsyncMaybe {
 				nxt = await gen.next(maybe.val);
 			} else {
 				halted = true;
-				nxt = await gen.return(undefined as any);
+				nxt = await gen.return(undefined as never);
 			}
 		}
 		return halted ? Maybe.nothing : Maybe.just(nxt.value);
@@ -860,5 +860,5 @@ export namespace AsyncMaybe {
 	}
 
 	/** An async generator that yields `Maybe` and returns a value. */
-	export type Go<TReturn> = AsyncGenerator<Maybe<unknown>, TReturn, unknown>;
+	export type Go<TReturn> = AsyncGenerator<Maybe<unknown>, TReturn>;
 }

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -139,7 +139,7 @@ describe("Validation", () => {
 			const results: [number, string][] = [];
 			const vdn = Validation.forEach(["a", "b"], (char, idx) => {
 				results.push([idx, char]);
-				return Validation.ok<void, Str>(undefined);
+				return Validation.ok<undefined, Str>(undefined);
 			});
 			expect(vdn).to.deep.equal(Validation.ok(undefined));
 			expect(results).to.deep.equal([
@@ -439,7 +439,7 @@ describe("AsyncValidation", () => {
 			const vdn = await AsyncValidation.forEach(gen(), (char, idx) =>
 				delay(1).then(() => {
 					results.push([idx, char]);
-					return Validation.ok<void, Str>(undefined);
+					return Validation.ok<undefined, Str>(undefined);
 				}),
 			);
 			expect(vdn).to.deep.equal(Validation.ok(undefined));
@@ -544,7 +544,7 @@ describe("AsyncValidation", () => {
 				(char, idx) =>
 					delay(char === "a" ? 50 : 10).then(() => {
 						results.push([idx, char]);
-						return Validation.ok<void, Str>(undefined);
+						return Validation.ok<undefined, Str>(undefined);
 					}),
 			);
 			expect(vdn).to.deep.equal(Validation.ok(undefined));

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
 	"extends": "./tsconfig.json",
+	"include": ["./src"],
 	"exclude": ["**/*.test.ts", "**/_test/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true
 	},
-	"include": ["./src"]
+	"include": ["./vitest.config.ts", "./src"]
 }


### PR DESCRIPTION
Move to tighter linting rules using the `strict-type-checked` and `stylistic-type-checked` recommended rule sets from typescript-eslint.