### PR TITLE
Support TypeScript 5.3

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,6 +56,7 @@ jobs:
           - ~5.0
           - ~5.1
           - ~5.2
+          - ~5.3
           - next
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.10.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
-				"@typescript-eslint/eslint-plugin": "^6.4.1",
-				"@typescript-eslint/parser": "^6.4.1",
+				"@typescript-eslint/eslint-plugin": "^6.15.0",
+				"@typescript-eslint/parser": "^6.15.0",
 				"@vitest/coverage-v8": "^0.34.1",
 				"eslint": "^8.47.0",
 				"eslint-config-prettier": "^9.0.0",
@@ -20,8 +20,8 @@
 				"prettier": "3.0.2",
 				"rimraf": "^3.0.2",
 				"ts-node": "^10.9.1",
-				"typedoc": "0.25.1",
-				"typescript": "~5.2",
+				"typedoc": "0.25.4",
+				"typescript": "~5.3",
 				"vitest": "^0.34.1"
 			},
 			"engines": {
@@ -665,9 +665,9 @@
 			"dev": true
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.12",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
 		"node_modules/@types/json5": {
@@ -683,22 +683,22 @@
 			"dev": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+			"version": "7.5.6",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+			"integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.1.tgz",
-			"integrity": "sha512-3F5PtBzUW0dYlq77Lcqo13fv+58KDwUib3BddilE8ajPJT+faGgxmI9Sw+I8ZS22BYwoir9ZhNXcLi+S+I2bkw==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
+			"integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.4.1",
-				"@typescript-eslint/type-utils": "6.4.1",
-				"@typescript-eslint/utils": "6.4.1",
-				"@typescript-eslint/visitor-keys": "6.4.1",
+				"@typescript-eslint/scope-manager": "6.15.0",
+				"@typescript-eslint/type-utils": "6.15.0",
+				"@typescript-eslint/utils": "6.15.0",
+				"@typescript-eslint/visitor-keys": "6.15.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -724,15 +724,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.1.tgz",
-			"integrity": "sha512-610G6KHymg9V7EqOaNBMtD1GgpAmGROsmfHJPXNLCU9bfIuLrkdOygltK784F6Crboyd5tBFayPB7Sf0McrQwg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
+			"integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.4.1",
-				"@typescript-eslint/types": "6.4.1",
-				"@typescript-eslint/typescript-estree": "6.4.1",
-				"@typescript-eslint/visitor-keys": "6.4.1",
+				"@typescript-eslint/scope-manager": "6.15.0",
+				"@typescript-eslint/types": "6.15.0",
+				"@typescript-eslint/typescript-estree": "6.15.0",
+				"@typescript-eslint/visitor-keys": "6.15.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -752,13 +752,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.1.tgz",
-			"integrity": "sha512-p/OavqOQfm4/Hdrr7kvacOSFjwQ2rrDVJRPxt/o0TOWdFnjJptnjnZ+sYDR7fi4OimvIuKp+2LCkc+rt9fIW+A==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
+			"integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.4.1",
-				"@typescript-eslint/visitor-keys": "6.4.1"
+				"@typescript-eslint/types": "6.15.0",
+				"@typescript-eslint/visitor-keys": "6.15.0"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -769,13 +769,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.1.tgz",
-			"integrity": "sha512-7ON8M8NXh73SGZ5XvIqWHjgX2f+vvaOarNliGhjrJnv1vdjG0LVIz+ToYfPirOoBi56jxAKLfsLm40+RvxVVXA==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
+			"integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.4.1",
-				"@typescript-eslint/utils": "6.4.1",
+				"@typescript-eslint/typescript-estree": "6.15.0",
+				"@typescript-eslint/utils": "6.15.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -796,9 +796,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
-			"integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
+			"integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -809,13 +809,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.1.tgz",
-			"integrity": "sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
+			"integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.4.1",
-				"@typescript-eslint/visitor-keys": "6.4.1",
+				"@typescript-eslint/types": "6.15.0",
+				"@typescript-eslint/visitor-keys": "6.15.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -836,17 +836,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.1.tgz",
-			"integrity": "sha512-F/6r2RieNeorU0zhqZNv89s9bDZSovv3bZQpUNOmmQK1L80/cV4KEu95YUJWi75u5PhboFoKUJBnZ4FQcoqhDw==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
+			"integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.4.1",
-				"@typescript-eslint/types": "6.4.1",
-				"@typescript-eslint/typescript-estree": "6.4.1",
+				"@typescript-eslint/scope-manager": "6.15.0",
+				"@typescript-eslint/types": "6.15.0",
+				"@typescript-eslint/typescript-estree": "6.15.0",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -861,12 +861,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.1.tgz",
-			"integrity": "sha512-y/TyRJsbZPkJIZQXrHfdnxVnxyKegnpEvnRGNam7s3TRR2ykGefEWOhaef00/UUN3IZxizS7BTO3svd3lCOJRQ==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
+			"integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.4.1",
+				"@typescript-eslint/types": "6.15.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -3828,9 +3828,9 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.1.tgz",
-			"integrity": "sha512-c2ye3YUtGIadxN2O6YwPEXgrZcvhlZ6HlhWZ8jQRNzwLPn2ylhdGqdR8HbyDRyALP8J6lmSANILCkkIdNPFxqA==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.4.tgz",
+			"integrity": "sha512-Du9ImmpBCw54bX275yJrxPVnjdIyJO/84co0/L9mwe0R3G4FSR6rQ09AlXVRvZEGMUg09+z/usc8mgygQ1aidA==",
 			"dev": true,
 			"dependencies": {
 				"lunr": "^2.3.9",
@@ -3845,7 +3845,7 @@
 				"node": ">= 16"
 			},
 			"peerDependencies": {
-				"typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x"
+				"typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x"
 			}
 		},
 		"node_modules/typedoc/node_modules/brace-expansion": {
@@ -3873,9 +3873,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
 		"postpublish": "npm run clean"
 	},
 	"devDependencies": {
-		"@typescript-eslint/eslint-plugin": "^6.4.1",
-		"@typescript-eslint/parser": "^6.4.1",
+		"@typescript-eslint/eslint-plugin": "^6.15.0",
+		"@typescript-eslint/parser": "^6.15.0",
 		"@vitest/coverage-v8": "^0.34.1",
 		"eslint": "^8.47.0",
 		"eslint-config-prettier": "^9.0.0",
@@ -73,8 +73,8 @@
 		"prettier": "3.0.2",
 		"rimraf": "^3.0.2",
 		"ts-node": "^10.9.1",
-		"typedoc": "0.25.1",
-		"typescript": "~5.2",
+		"typedoc": "0.25.4",
+		"typescript": "~5.3",
 		"vitest": "^0.34.1"
 	},
 	"volta": {

--- a/src/cmb.ts
+++ b/src/cmb.ts
@@ -119,7 +119,9 @@
  * [augmentation]:
  *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  *
- * @example Non-generic implementation
+ * ## Example implementations
+ *
+ * ### Non-generic implementation
  *
  * Consider a type that combines strings using concatenation:
  *
@@ -135,7 +137,7 @@
  * }
  * ```
  *
- * @example Generic implementation with no `Semigroup` requirements
+ * ### Generic implementation with no `Semigroup` requirements
  *
  * Consider a type that combines arrays using concatenation:
  *
@@ -154,7 +156,7 @@
  * Notice how `Concat` is generic, but there are no special requirements for
  * implementing `[Semigroup.cmb]`.
  *
- * @example Generic implementation with a `Semigroup` requirement
+ * ### Generic implementation with one `Semigroup` requirement
  *
  * Consider a type that combines promises by combining their results, which
  * requires that the results also implement `Semigroup`:
@@ -184,7 +186,7 @@
  * Then, we require that `this` and `that` are `Async<T>` where `T extends
  * Semigroup<T>`. This allows us to use `cmb` to implement our desired behavior.
  *
- * @example Generic implementation with multiple `Semigroup` requirements
+ * ### Generic implementation with multiple `Semigroup` requirements
  *
  * Consider a type that combines two values pairwise, which requires that each
  * value implement `Semigroup`:
@@ -208,7 +210,7 @@
  * now two method-scoped generic parameters that are each required to implement
  * `Semigroup`.
  *
- * @example Non-generic augmentation
+ * ### Non-generic augmentation
  *
  * Consider a global augmentation for the `String` prototype:
  *
@@ -226,7 +228,7 @@
  * };
  * ```
  *
- * @example Generic augmentation
+ * ### Generic augmentation
  *
  * Consider a module augmentation for an externally defined `Pair` type:
  *

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -127,7 +127,9 @@ import { Semigroup } from "./cmb.js";
  * [augmentation]:
  *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  *
- * @example Non-generic implementation
+ * ## Example implementations
+ *
+ * ### Non-generic implementation
  *
  * Consider a `Book` type that determines equality by comparing ISBNs:
  *
@@ -162,7 +164,7 @@ import { Semigroup } from "./cmb.js";
  * }
  * ```
  *
- * @example Generic implementation with no `Eq` requirements
+ * ### Generic implementation with no `Eq` requirements
  *
  * Consider a type that determines equality by comparing the lengths of arrays:
  *
@@ -181,7 +183,7 @@ import { Semigroup } from "./cmb.js";
  * Notice how `Len` is generic, but there are no special requirements for
  * implementing `[Eq.eq]`.
  *
- * @example Generic implementation with an `Eq` requirement
+ * ### Generic implementation with one `Eq` requirement
  *
  * Consider a type that determines equality for arrays by comparing their
  * elements lexicographically, which requires that the elements implement `Eq`:
@@ -205,7 +207,7 @@ import { Semigroup } from "./cmb.js";
  * Then, we require that `this` and `that` are `Arr<T>` where `T extends Eq<T>`.
  * This allows us to use `ieq` to implement our desired behavior.
  *
- * @example Generic implementation with multiple `Eq` requirements
+ * ### Generic implementation with multiple `Eq` requirements
  *
  * Consider a `Pair` type that determines equality for two distinct values,
  * which requires that each value has a distinct implementation for `Eq`:
@@ -229,7 +231,7 @@ import { Semigroup } from "./cmb.js";
  * two method-scoped generic parameters that are each required to implement
  * `Eq`.
  *
- * @example Non-generic augmentation
+ * ### Non-generic augmentation
  *
  * Consider a module augmentation for an externally defined `Book` type:
  *
@@ -248,7 +250,7 @@ import { Semigroup } from "./cmb.js";
  * };
  * ```
  *
- * @example Generic augmentation
+ * ### Generic augmentation
  *
  * Consider a global augmentation for the `Array` prototype:
  *
@@ -446,7 +448,9 @@ export function ieq<T extends Eq<T>>(
  * [augmentation]:
  *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  *
- * @example Non-generic implementation
+ * ## Example implementations
+ *
+ * ### Non-generic implementation
  *
  * Consider a `Book` type that determines ordering by comparing ISBNs:
  *
@@ -495,7 +499,7 @@ export function ieq<T extends Eq<T>>(
  * format. Notice how the semigroup behavior of `Ordering` along with the `cmb`
  * function is used here to combine two `Ordering`.
  *
- * @example Generic implementation with no `Ord` requirements
+ * ### Generic implementation with no `Ord` requirements
  *
  * Consider a type that orders arrays by comparing their lengths:
  *
@@ -518,7 +522,7 @@ export function ieq<T extends Eq<T>>(
  * Notice how `Len` is generic, but there are no special requirements for
  * implementing `[Ord.cmp]`.
  *
- * @example Generic implementation with an `Ord` requirement
+ * ### Generic implementation with one `Ord` requirement
  *
  * Consider a type that orders arrays by comparing their elements
  * lexicographically, which requires that the elements implement `Ord`:
@@ -546,7 +550,7 @@ export function ieq<T extends Eq<T>>(
  * Then, we require that `this` and `that` are `Arr<T>` where `T extends
  * Ord<T>`. This allows us to use `icmp` to implement our desired behavior.
  *
- * @example Generic implementation with multiple `Ord` requirements
+ * ### Generic implementation with multiple `Ord` requirements
  *
  * Consider a `Pair` type that orders two distinct values lexicographically,
  * which requires that each value is an implementor of `Ord`:
@@ -578,7 +582,7 @@ export function ieq<T extends Eq<T>>(
  * two method-scoped generic parameters that are each required to implement
  * `Ord`.
  *
- * @example Non-generic augmentation
+ * ### Non-generic augmentation
  *
  * Consider a module augmentation for an externally defined `Book` type:
  *
@@ -602,7 +606,7 @@ export function ieq<T extends Eq<T>>(
  * };
  * ```
  *
- * @example Generic augmentation
+ * ### Generic augmentation
  *
  * Consider a global augmentation for the `Array` prototype:
  *


### PR DESCRIPTION
- Bump TypeScript, typescript-eslint, and typedoc
- Add TypeScript 5.3 to the CI test matrix
- Remove `@example` tags, use Markdown headings instead (rich text in example titles is not supported by typedoc)