### PR TITLE
Introduce more conversion functions for `Either` and `Validation`

### DIFF
--- a/src/either.test.ts
+++ b/src/either.test.ts
@@ -56,6 +56,26 @@ describe("Either", () => {
 		});
 	});
 
+	describe("fromNullish", () => {
+		it("returns a fallback value in a Left if the argument is null", () => {
+			expect(Either.fromNullish<2, 1>(null, () => 1)).to.deep.equal(
+				Either.left(1),
+			);
+		});
+
+		it("returns a fallback value in a Left if the argument is undefined", () => {
+			expect(Either.fromNullish<2, 1>(undefined, () => 1)).to.deep.equal(
+				Either.left(1),
+			);
+		});
+
+		it("returns the argument in a Right if it is non-nullish", () => {
+			expect(Either.fromNullish<2, 1>(2, () => 1)).to.deep.equal(
+				Either.right(2),
+			);
+		});
+	});
+
 	describe("fromValidation", () => {
 		it("constructs a Left if the Validation is an Err", () => {
 			const either = Either.fromValidation(Validation.err<1, 2>(1));
@@ -64,6 +84,53 @@ describe("Either", () => {
 
 		it("constructs a Right if the Validation is an Ok", () => {
 			const either = Either.fromValidation(Validation.ok<2, 1>(2));
+			expect(either).to.deep.equal(Either.right(2));
+		});
+	});
+
+	describe("wrapNullishFn", () => {
+		it("adapts the function to return a Left if it returns null", () => {
+			const f = Either.wrapNullishFn(
+				(() => null) as (two: 2) => [2, 4] | null,
+				(two): [1, typeof two] => [1, two],
+			);
+			const either = f(2);
+			expect(either).to.deep.equal(Either.left([1, 2]));
+		});
+
+		it("adapts the function to return a Left if it returns undefined", () => {
+			const f = Either.wrapNullishFn(
+				(() => undefined) as (two: 2) => [2, 4] | undefined,
+				(two): [1, typeof two] => [1, two],
+			);
+			const either = f(2);
+			expect(either).to.deep.equal(Either.left([1, 2]));
+		});
+
+		it("adapts the function to return a Right if it returns a non-nullish value", () => {
+			const f = Either.wrapNullishFn(
+				(two: 2): [2, 4] | null | undefined => [two, 4],
+				(two): [1, typeof two] => [1, two],
+			);
+			const either = f(2);
+			expect(either).to.deep.equal(Either.right([2, 4]));
+		});
+	});
+
+	describe("wrapPredicateFn", () => {
+		it("adapts the predicate to return its argument in a Left if not satisfied", () => {
+			const f = Either.wrapPredicateFn(
+				(num: 1 | 2): num is 2 => num === 2,
+			);
+			const either = f(1);
+			expect(either).to.deep.equal(Either.left(1));
+		});
+
+		it("adapts the predicate to return its argument in a Right if satisfied", () => {
+			const f = Either.wrapPredicateFn(
+				(num: 1 | 2): num is 2 => num === 2,
+			);
+			const either = f(2);
 			expect(either).to.deep.equal(Either.right(2));
 		});
 	});

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -62,25 +62,25 @@ describe("Maybe", () => {
 			expect(Maybe.fromNullish<1>(null)).to.equal(Maybe.nothing);
 		});
 
-		it("returns any non-undefined, non-null argument in a Just", () => {
+		it("returns the argument in a Just if it is non-nullish", () => {
 			expect(Maybe.fromNullish<1>(1)).to.deep.equal(Maybe.just(1));
 		});
 	});
 
 	describe("wrapNullishFn", () => {
-		it("adapts the function to return Nothing if it returns undefined", () => {
-			const f = Maybe.wrapNullishFn((): 1 | undefined => undefined);
-			const maybe = f();
-			expect(maybe).to.equal(Maybe.nothing);
-		});
-
 		it("adapts the function to return Nothing if it returns null", () => {
 			const f = Maybe.wrapNullishFn((): 1 | null => null);
 			const maybe = f();
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
-		it("adapts the function to wrap a non-undefined, non-null result in a Just", () => {
+		it("adapts the function to return Nothing if it returns undefined", () => {
+			const f = Maybe.wrapNullishFn((): 1 | undefined => undefined);
+			const maybe = f();
+			expect(maybe).to.equal(Maybe.nothing);
+		});
+
+		it("adapts the function to return a Just if it returns a non-nullish value", () => {
 			const f = Maybe.wrapNullishFn((): 1 => 1);
 			const maybe = f();
 			expect(maybe).to.deep.equal(Maybe.just(1));

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -125,11 +125,14 @@ export namespace Maybe {
 		return (...args) => fromNullish(f(...args));
 	}
 
-	/** Adapt a predicate into a function that returns `Maybe`. */
+	/**
+	 * Adapt a refining predicate function into a function that returns `Maybe`.
+	 */
 	export function wrapPredicateFn<T, T1 extends T>(
 		f: (val: T) => val is T1,
 	): (val: T) => Maybe<T1>;
 
+	/** Adapt a predicate function into a function that returns `Maybe`. */
 	export function wrapPredicateFn<T>(
 		f: (val: T) => boolean,
 	): (val: T) => Maybe<T>;

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -57,6 +57,26 @@ describe("Validation", () => {
 		});
 	});
 
+	describe("fromNullish", () => {
+		it("returns a fallback value in an Err if the argument is null", () => {
+			expect(Validation.fromNullish<2, 1>(null, () => 1)).to.deep.equal(
+				Validation.err(1),
+			);
+		});
+
+		it("returns a fallback value in an Err if the argument is undefined", () => {
+			expect(
+				Validation.fromNullish<2, 1>(undefined, () => 1),
+			).to.deep.equal(Validation.err(1));
+		});
+
+		it("returns the argument in an Ok if it is non-nullish", () => {
+			expect(Validation.fromNullish<2, 1>(2, () => 1)).to.deep.equal(
+				Validation.ok(2),
+			);
+		});
+	});
+
 	describe("fromEither", () => {
 		it("constructs an Err if the Either is a Left", () => {
 			expect(Validation.fromEither(Either.left<1, 2>(1))).to.deep.equal(
@@ -68,6 +88,53 @@ describe("Validation", () => {
 			expect(Validation.fromEither(Either.right<2, 1>(2))).to.deep.equal(
 				Validation.ok(2),
 			);
+		});
+	});
+
+	describe("wrapNullishFn", () => {
+		it("adapts the function to return an Err if it returns null", () => {
+			const f = Validation.wrapNullishFn(
+				(() => null) as (two: 2) => [2, 4] | null,
+				(two): [1, typeof two] => [1, two],
+			);
+			const vdn = f(2);
+			expect(vdn).to.deep.equal(Validation.err([1, 2]));
+		});
+
+		it("adapts the function to return an Err if it returns undefined", () => {
+			const f = Validation.wrapNullishFn(
+				(() => undefined) as (two: 2) => [2, 4] | undefined,
+				(two): [1, typeof two] => [1, two],
+			);
+			const vdn = f(2);
+			expect(vdn).to.deep.equal(Validation.err([1, 2]));
+		});
+
+		it("adapts the function to return an Ok if it returns a non-nullish value", () => {
+			const f = Validation.wrapNullishFn(
+				(two: 2): [2, 4] | null | undefined => [two, 4],
+				(two): [1, typeof two] => [1, two],
+			);
+			const vdn = f(2);
+			expect(vdn).to.deep.equal(Validation.ok([2, 4]));
+		});
+	});
+
+	describe("wrapPredicateFn", () => {
+		it("adapts the predicate to return its argument in an Err if not satisfied", () => {
+			const f = Validation.wrapPredicateFn(
+				(num: 1 | 2): num is 2 => num === 2,
+			);
+			const vdn = f(1);
+			expect(vdn).to.deep.equal(Validation.err(1));
+		});
+
+		it("adapts the predicate to return its argument in an Ok if satisfied", () => {
+			const f = Validation.wrapPredicateFn(
+				(num: 1 | 2): num is 2 => num === 2,
+			);
+			const vdn = f(2);
+			expect(vdn).to.deep.equal(Validation.ok(2));
 		});
 	});
 


### PR DESCRIPTION
- Convert from nullish values with `fromNullish` and `wrapNullishFn`
- Wrap predicate functions with `wrapPredicateFn`