### PR TITLE
Introduce constructors for void values

### DIFF
--- a/src/either.test.ts
+++ b/src/either.test.ts
@@ -56,6 +56,14 @@ describe("Either", () => {
 		});
 	});
 
+	describe("unit", () => {
+		it("constructs a Right variant with an undefined value", () => {
+			const either = Either.unit<1>();
+			expect(either).to.be.an.instanceOf(Either.Right);
+			expect(either.val).to.be.undefined;
+		});
+	});
+
 	describe("fromValidation", () => {
 		it("constructs a Left if the Validation is an Err", () => {
 			const either = Either.fromValidation(Validation.err<1, 2>(1));

--- a/src/either.ts
+++ b/src/either.ts
@@ -116,6 +116,11 @@ export namespace Either {
 		return new Right(val);
 	}
 
+	/** Construct a `Right` with a `void` value. */
+	export function unit<E = never>(): Either<E, void> {
+		return right(undefined);
+	}
+
 	/** Construct an `Either` from a `Validation`. */
 	export function fromValidation<E, T>(vdn: Validation<E, T>): Either<E, T> {
 		return vdn.match(left, right);

--- a/src/ior.test.ts
+++ b/src/ior.test.ts
@@ -62,6 +62,14 @@ describe("Ior", () => {
 		});
 	});
 
+	describe("unit", () => {
+		it("constructs a Right variant with an undefined value", () => {
+			const ior = Ior.unit<1>();
+			expect(ior).to.be.an.instanceOf(Ior.Right);
+			expect(ior.val).to.be.undefined;
+		});
+	});
+
 	describe("both", () => {
 		it("constructs a Both variant", () => {
 			const ior = Ior.both<1, 2>(1, 2);
@@ -70,6 +78,15 @@ describe("Ior", () => {
 			expect((ior as Ior.Both<1, 2>).fst).to.equal(1);
 			expect((ior as Ior.Both<1, 2>).snd).to.equal(2);
 			expect(ior.val).to.deep.equal([1, 2]);
+		});
+	});
+
+	describe("write", () => {
+		it("constructs a Both variant with an undefined right-hand value", () => {
+			const ior = Ior.write<1>(1);
+			expect(ior).to.be.an.instanceOf(Ior.Both);
+			expect((ior as Ior.Both<1, void>).fst).to.equal(1);
+			expect((ior as Ior.Both<1, void>).snd).to.be.undefined;
 		});
 	});
 

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -125,9 +125,19 @@ export namespace Ior {
 		return new Right(val);
 	}
 
+	/** Construct a `Right` with a `void` value. */
+	export function unit<A = never>(): Ior<A, void> {
+		return right(undefined);
+	}
+
 	/** Construct a `Both`. */
 	export function both<A, B>(fst: A, snd: B): Ior<A, B> {
 		return new Both(fst, snd);
+	}
+
+	/** Construct a `Both` with a `void` right-hand value. */
+	export function write<A>(fst: A): Ior<A, void> {
+		return both(fst, undefined);
 	}
 
 	/** Construct an `Ior` from an `Either`. */

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -53,6 +53,14 @@ describe("Maybe", () => {
 		});
 	});
 
+	describe("unit", () => {
+		it("constructs a Just with an undefined value", () => {
+			const maybe = Maybe.unit();
+			expect(maybe).to.be.an.instanceOf(Maybe.Just);
+			expect((maybe as Maybe.Just<void>).val).to.be.undefined;
+		});
+	});
+
 	describe("fromNullish", () => {
 		it("returns Nothing if the argument is undefined", () => {
 			expect(Maybe.fromNullish<1>(undefined)).to.equal(Maybe.nothing);

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -107,6 +107,11 @@ export namespace Maybe {
 		return new Just(val);
 	}
 
+	/** Construct a `Just` with a `void` value. */
+	export function unit(): Maybe<void> {
+		return just(undefined);
+	}
+
 	/**
 	 * Consruct a `Maybe` from a value that is potentially `null` or
 	 * `undefined`.

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -57,6 +57,14 @@ describe("Validation", () => {
 		});
 	});
 
+	describe("unit", () => {
+		it("constructs an Ok variant with an undefined value", () => {
+			const vdn = Validation.unit();
+			expect(vdn).to.be.an.instanceOf(Validation.Ok);
+			expect(vdn.val).to.be.undefined;
+		});
+	});
+
 	describe("fromEither", () => {
 		it("constructs an Err if the Either is a Left", () => {
 			expect(Validation.fromEither(Either.left<1, 2>(1))).to.deep.equal(

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -115,6 +115,11 @@ export namespace Validation {
 		return new Ok(val);
 	}
 
+	/** Construct a successful `Validation` with a `void` value. */
+	export function unit<E = never>(): Validation<E, void> {
+		return ok(undefined);
+	}
+
 	/** Construct a `Validation` from an `Either`. */
 	export function fromEither<A, B>(either: Either<A, B>): Validation<A, B> {
 		return either.match(err, ok);


### PR DESCRIPTION
Add constructors that return `void` types. Useful for yielding in generator comprehensions and returning data types from functions that would otherwise return `void` on success.